### PR TITLE
Improvements and package version 1.1.0

### DIFF
--- a/FunctionalCSharp.Test/FpPipeTest.cs
+++ b/FunctionalCSharp.Test/FpPipeTest.cs
@@ -30,7 +30,8 @@ internal class FpPipeTest : FpTestBase
                 FpPipeTest.actionIntoParameters = GenerateParams(actionType.GenericTypeArguments.Length);
                 FpPipeTest.actionIntoLastArg = FpPipeTest.actionIntoParameters.Last();
 
-                intoMethod.Invoke(null, BuildParameters(FpPipeTest.actionIntoLastArg, @delegate, FpPipeTest.actionIntoParameters.SkipLast(1)));
+                var result = intoMethod.Invoke(null, BuildParameters(FpPipeTest.actionIntoLastArg, @delegate, FpPipeTest.actionIntoParameters.SkipLast(1)));
+                Assert.That(GetResult(isAsync, result) as Unit, Is.SameAs(Fp.UnitValue));
             }
         });
     }
@@ -84,7 +85,7 @@ internal class FpPipeTest : FpTestBase
     #region FpPipeTest
 
     protected object? GetResult(bool isAsync, object? result)
-        => isAsync ? (result as Task<object>)!.Result : result;
+        => isAsync ? ((result as Task<object>)?.Result ?? (result as Task<Unit>)!.Result) : result;
 
     protected virtual IEnumerable<MethodInfo> GetActionIntoMethods(bool isAsync = false)
         => GetMethods(

--- a/FunctionalCSharp.Test/FpTest.cs
+++ b/FunctionalCSharp.Test/FpTest.cs
@@ -17,4 +17,91 @@ internal class FpTest
         Assert.That(result(), Is.SameAs(value));
     }
 
+    public class BaseClass { }
+    public class DerivedClass : BaseClass { }
+
+    [Test]
+    public void As_ValidConversion_ShouldReturnConvertedValue()
+    {
+        // Arrange
+        BaseClass baseObject = new DerivedClass();
+
+        // Act
+        var result = baseObject.As<DerivedClass>();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.InstanceOf<DerivedClass>());
+            Assert.That(result, Is.SameAs(baseObject));
+        });
+    }
+
+    [Test]
+    public void As_InvalidConversion_ShouldReturnNull()
+    {
+        // Arrange
+        BaseClass baseObject = new BaseClass();
+
+        // Act
+        var result = baseObject.As<DerivedClass>();
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void As_NullInput_ShouldReturnNull()
+    {
+        // Arrange
+        BaseClass? baseObject = null;
+
+        // Act
+        var result = baseObject.As<DerivedClass>();
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void Cast_ValidConversion_ShouldReturnConvertedValue()
+    {
+        // Arrange
+        BaseClass baseObject = new DerivedClass();
+
+        // Act
+        var result = baseObject.Cast<DerivedClass>();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.InstanceOf<DerivedClass>());
+            Assert.That(result, Is.SameAs(baseObject));
+        });
+    }
+
+    [Test]
+    public void Cast_InvalidConversion_ShouldThrowInvalidCastException()
+    {
+        // Arrange
+        BaseClass baseObject = new BaseClass();
+
+        // Act & Assert
+        Assert.Throws<InvalidCastException>(() => baseObject.Cast<DerivedClass>());
+    }
+
+    [Test]
+    public void Cast_NullInput_ShouldReturnNull()
+    {
+        // Arrange
+        BaseClass? baseObject = null;
+
+        // Act
+        var result = baseObject.Cast<DerivedClass>();
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
 }

--- a/FunctionalCSharp.Test/FpTest.cs
+++ b/FunctionalCSharp.Test/FpTest.cs
@@ -65,7 +65,7 @@ internal class FpTest
     }
 
     [Test]
-    public void Cast_ValidConversion_ShouldReturnConvertedValue()
+    public void Cast_ClassValidConversion_ShouldReturnConvertedValue()
     {
         // Arrange
         BaseClass baseObject = new DerivedClass();
@@ -83,7 +83,7 @@ internal class FpTest
     }
 
     [Test]
-    public void Cast_InvalidConversion_ShouldThrowInvalidCastException()
+    public void Cast_ClassInvalidConversion_ShouldThrowInvalidCastException()
     {
         // Arrange
         BaseClass baseObject = new BaseClass();
@@ -93,7 +93,7 @@ internal class FpTest
     }
 
     [Test]
-    public void Cast_NullInput_ShouldReturnNull()
+    public void Cast_ClassNullInput_ShouldReturnNull()
     {
         // Arrange
         BaseClass? baseObject = null;
@@ -104,4 +104,30 @@ internal class FpTest
         // Assert
         Assert.That(result, Is.Null);
     }
+
+    public struct MyStruct { public int Value { get; set; } }
+
+    [Test]
+    public void Cast_StructValidConversion_ShouldReturnConvertedValue()
+    {
+        // Arrange
+        object myStruct = new MyStruct() { Value = 5 };
+
+        // Act
+        var result = myStruct.Cast<MyStruct>();
+
+        // Assert
+        Assert.That(myStruct, Is.EqualTo(result));
+    }
+
+    [Test]
+    public void Cast_StructInvalidConversion_ShouldThrowInvalidCastException()
+    {
+        // Arrange
+        object baseObject = 5;
+
+        // Act & Assert
+        Assert.Throws<InvalidCastException>(() => baseObject.Cast<MyStruct>());
+    }
+
 }

--- a/FunctionalCSharp.Test/FpTest.cs
+++ b/FunctionalCSharp.Test/FpTest.cs
@@ -27,7 +27,6 @@ internal class FpTest
         Assert.DoesNotThrow(() => myObject.ToStatement());
     }
 
-    // Test for the AsUnit method
     [Test]
     public void AsUnit_Test()
     {

--- a/FunctionalCSharp.Test/FpTest.cs
+++ b/FunctionalCSharp.Test/FpTest.cs
@@ -8,13 +8,37 @@ internal class FpTest
     public void AsFunc_PassValue_ResultOfFuncIsThePassedValue()
     {
         // ARRANGE
-        object value = new object();
+        object value = new();
 
         // ACT
         var result = Fp.AsFunc(value);
 
         // ASSERT
         Assert.That(result(), Is.SameAs(value));
+    }
+
+    [Test]
+    public void ToStatement_Test()
+    {
+        // Arrange
+        object myObject = new();
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => myObject.ToStatement());
+    }
+
+    // Test for the AsUnit method
+    [Test]
+    public void AsUnit_Test()
+    {
+        // Arrange
+        object myObject = new object();
+
+        // Act
+        Unit result = myObject.AsUnit();
+
+        // Assert
+        Assert.That(result, Is.SameAs(Fp.UnitValue));
     }
 
     public class BaseClass { }

--- a/FunctionalCSharp.Test/Unit/FpUnitTest.cs
+++ b/FunctionalCSharp.Test/Unit/FpUnitTest.cs
@@ -8,10 +8,6 @@ internal class FpUnitTest : FpTestBase
 
     private static object[] parameters = new object[0];
 
-    [Test]
-    public void Void_Passes()
-        => new Unit().Void();
-
     [TestCase(false)]
     [TestCase(true)]
     public void Create_AllOverloadedCreateMethods_ArgumentsPassedCorrectlyAndReturnsUnit(bool isAsync)

--- a/FunctionalCSharp/Fp.cs
+++ b/FunctionalCSharp/Fp.cs
@@ -17,4 +17,25 @@ public static partial class Fp
         return () => value;
     }
 
+    /// <summary>
+    /// Performs a safe type conversion or casting on the input object to the specified type.
+    /// If the conversion is valid, returns the converted value; otherwise, returns null.
+    /// </summary>
+    /// <typeparam name="TOut">The type to which the input object should be converted.</typeparam>
+    /// <param name="in">The input object to be converted.</param>
+    /// <returns>The converted value if conversion is valid; otherwise, null.</returns>
+    public static TOut? As<TOut>(this object? @in)
+        where TOut : class
+        => @in as TOut;
+
+    /// <summary>
+    /// Performs a type conversion or casting on the input object to the specified type.
+    /// If the conversion is valid, returns the converted value; otherwise, throws an InvalidCastException.
+    /// </summary>
+    /// <typeparam name="TOut">The type to which the input object should be converted.</typeparam>
+    /// <param name="in">The input object to be converted.</param>
+    /// <returns>The converted value if the conversion is valid.</returns>
+    /// <exception cref="InvalidCastException">Thrown when the conversion is not possible.</exception>
+    public static TOut? Cast<TOut>(this object? @in)
+        => (TOut?)@in;
 }

--- a/FunctionalCSharp/Fp.cs
+++ b/FunctionalCSharp/Fp.cs
@@ -17,6 +17,22 @@ public static partial class Fp
         return () => value;
     }
 
+#pragma warning disable IDE0060 // Remove unused parameter
+    /// <summary>
+    /// Converts the given object into a statement without returning any value.
+    /// </summary>
+    /// <param name="value">The object to be converted into a statement.</param>
+    public static void ToStatement(this object value) { }
+
+    /// <summary>
+    /// Converts the given object into a <see cref="Unit"/> value.
+    /// </summary>
+    /// <param name="value">The object to be converted into a <see cref="Unit"/> value.</param>
+    /// <returns>A <see cref="Unit"/> value representing the conversion completion.</returns>
+    public static Unit AsUnit(this object value)
+        => UnitValue;
+#pragma warning restore IDE0060 // Remove unused parameter
+
     /// <summary>
     /// Performs a safe type conversion or casting on the input object to the specified type.
     /// If the conversion is valid, returns the converted value; otherwise, returns null.

--- a/FunctionalCSharp/FpAsyncPipe.cs
+++ b/FunctionalCSharp/FpAsyncPipe.cs
@@ -8,160 +8,240 @@ public static partial class Fp
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<TLast>(this TLast last,
         Action<TLast> action)
     {
         await Task.Run(() => action(last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, TLast>(this TLast last,
         Action<T1, TLast> action,
         T1 t1)
     {
         await Task.Run(() => action(t1, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, TLast>(this TLast last,
         Action<T1, T2, TLast> action,
         T1 t1, T2 t2)
     {
         await Task.Run(() => action(t1, t2, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, TLast>(this TLast last,
         Action<T1, T2, T3, TLast> action,
         T1 t1, T2 t2, T3 t3)
     {
         await Task.Run(() => action(t1, t2, t3, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, TLast>(this TLast last,
         Action<T1, T2, T3, T4, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4)
     {
         await Task.Run(() => action(t1, t2, t3, t4, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, T6, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, T6, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, T6, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, t6, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, T6, T7, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, T6, T7, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, T6, T7, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, t6, t7, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, T6, T7, T8, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, t6, t7, t8, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, t6, t7, t8, t9, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, last));
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) async pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static async Task IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TLast>(this TLast last,
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static async Task<Unit> IntoAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TLast>(this TLast last,
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15)
     {
         await Task.Run(() => action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, last));
+        return UnitValue;
     }
     #endregion Into Action
 

--- a/FunctionalCSharp/FpPipe.cs
+++ b/FunctionalCSharp/FpPipe.cs
@@ -9,160 +9,240 @@ public static partial class Fp
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<TLast>(this TLast last, 
         Action<TLast> action)
     {
         action(last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, TLast>(this TLast last, 
         Action<T1, TLast> action,
         T1 t1)
     {
         action(t1, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, TLast>(this TLast last, 
         Action<T1, T2, TLast> action,
         T1 t1, T2 t2)
     {
         action(t1, t2, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, TLast>(this TLast last, 
         Action<T1, T2, T3, TLast> action,
         T1 t1, T2 t2, T3 t3)
     {
         action(t1, t2, t3, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4)
     {
         action(t1, t2, t3, t4, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5)
     {
         action(t1, t2, t3, t4, t5, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, T6, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, T6, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, T6, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6)
     {
         action(t1, t2, t3, t4, t5, t6, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, T6, T7, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, T6, T7, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, T6, T7, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7)
     {
         action(t1, t2, t3, t4, t5, t6, t7, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, T6, T7, T8, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, T6, T7, T8, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, T6, T7, T8, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8)
     {
         action(t1, t2, t3, t4, t5, t6, t7, t8, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9)
     {
         action(t1, t2, t3, t4, t5, t6, t7, t8, t9, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10)
     {
         action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11)
     {
         action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12)
     {
         action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13)
     {
         action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14)
     {
         action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, last);
+        return UnitValue;
     }
     /// <summary>
     /// F#-like (|>) pipe function.
     /// </summary>
     /// <param name="action">Delegate which receives pipe'd value.</param>
-    public static void Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TLast>(this TLast last, 
+    /// <returns>
+    /// A <see cref="FunctionalCSharp.Unit"/> value representing the completion of the pipelining operation.
+    /// Enables method chaining for pipeline continuation.
+    /// </returns>
+    public static Unit Into<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TLast>(this TLast last, 
         Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TLast> action,
         T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15)
     {
         action(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, last);
+        return UnitValue;
     }
     #endregion Into Action
 

--- a/FunctionalCSharp/FunctionalCSharp.csproj
+++ b/FunctionalCSharp/FunctionalCSharp.csproj
@@ -6,12 +6,12 @@
     <Nullable>enable</Nullable>
     <PackageId>functional-c-sharp</PackageId>
     <Title>FunctionalCSharp</Title>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Pawlesh</Authors>
     <Description>FunctionalCSharp is a library aimed at helping developers write functional-style code in C#. </Description>
     <RepositoryUrl>https://github.com/Pawleshhh/FunctionalCSharp</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>functional oriented programming, C#, F#, CSharp, pipe, compose, partial application</PackageTags>
+    <PackageTags>functional oriented programming, C#, F#, CSharp, pipe, compose, partial application, unit</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 

--- a/FunctionalCSharp/Unit/Unit.cs
+++ b/FunctionalCSharp/Unit/Unit.cs
@@ -6,11 +6,6 @@
 public class Unit 
 {
 
-    /// <summary>
-    /// Helper method which converts an expression of functions to a statement.
-    /// </summary>
-    public void Void() { }
-
     #region Create
 
     /// <summary>


### PR DESCRIPTION
Into methods previously returning void now return Unit.
New methods:
- As
- Cast
- ToStatement
- AsUnit
Removed Unit.ToVoid

New package version - 1.1.0